### PR TITLE
enc_counts_per_rev parameter changed to enc_counts_per_rev_l/r

### DIFF
--- a/hardware/diffbot_system.cpp
+++ b/hardware/diffbot_system.cpp
@@ -42,7 +42,8 @@ hardware_interface::CallbackReturn DiffDriveArduinoHardware::on_init(
   cfg_.device = info_.hardware_parameters["device"];
   cfg_.baud_rate = std::stoi(info_.hardware_parameters["baud_rate"]);
   cfg_.timeout_ms = std::stoi(info_.hardware_parameters["timeout_ms"]);
-  cfg_.enc_counts_per_rev = std::stoi(info_.hardware_parameters["enc_counts_per_rev"]);
+  cfg_.enc_counts_per_rev_l = std::stoi(info_.hardware_parameters["enc_counts_per_rev_l"]);
+  cfg_.enc_counts_per_rev_r = std::stoi(info_.hardware_parameters["enc_counts_per_rev_r"]);
   if (info_.hardware_parameters.count("pid_p") > 0)
   {
     cfg_.pid_p = std::stoi(info_.hardware_parameters["pid_p"]);
@@ -56,8 +57,8 @@ hardware_interface::CallbackReturn DiffDriveArduinoHardware::on_init(
   }
   
 
-  wheel_l_.setup(cfg_.left_wheel_name, cfg_.enc_counts_per_rev);
-  wheel_r_.setup(cfg_.right_wheel_name, cfg_.enc_counts_per_rev);
+  wheel_l_.setup(cfg_.left_wheel_name, cfg_.enc_counts_per_rev_l);
+  wheel_r_.setup(cfg_.right_wheel_name, cfg_.enc_counts_per_rev_r);
 
 
   for (const hardware_interface::ComponentInfo & joint : info_.joints)

--- a/hardware/include/diffdrive_arduino/diffbot_system.hpp
+++ b/hardware/include/diffdrive_arduino/diffbot_system.hpp
@@ -47,7 +47,8 @@ struct Config
   std::string device = "";
   int baud_rate = 0;
   int timeout_ms = 0;
-  int enc_counts_per_rev = 0;
+  int enc_counts_per_rev_l = 0;
+  int enc_counts_per_rev_r = 0;
   int pid_p = 0;
   int pid_d = 0;
   int pid_i = 0;


### PR DESCRIPTION
**Feature that allows the user to configure a different cpr for each motor.** 

In this way, when the two motors have different cpr values and spin with different velocities for a closed-loop command with the same value for both motors (i.e. "m 50 50"), the user will be able to fix that and give each motor its corresponding cpr value. 

This feature will also help to improve odom issues as, if motors have very different cpr but are set with the same cpr value, it will be impossible to get good odom measurements.