### PR TITLE
Upgrade diffdrive_arduino to ROS Humble

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 project(diffdrive_arduino)
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 

--- a/include/diffdrive_arduino/diffdrive_arduino.h
+++ b/include/diffdrive_arduino/diffdrive_arduino.h
@@ -2,58 +2,56 @@
 #define DIFFDRIVE_ARDUINO_REAL_ROBOT_H
 
 #include <cstring>
-#include "rclcpp/rclcpp.hpp"
 
-#include "hardware_interface/base_interface.hpp"
-#include "hardware_interface/system_interface.hpp"
+#include "diffdrive_arduino/arduino_comms.h"
+#include "diffdrive_arduino/config.h"
+#include "diffdrive_arduino/wheel.h"
 #include "hardware_interface/handle.hpp"
 #include "hardware_interface/hardware_info.hpp"
+#include "hardware_interface/system_interface.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
-#include "hardware_interface/types/hardware_interface_status_values.hpp"
+#include "hardware_interface/visibility_control.h"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/state.hpp"
 
-#include "config.h"
-#include "wheel.h"
-#include "arduino_comms.h"
-
-
-using hardware_interface::return_type;
-
-class DiffDriveArduino : public hardware_interface::BaseInterface<hardware_interface::SystemInterface>
+namespace diffdrive_arduino
 {
-
-
+class DiffDriveArduino : public hardware_interface::SystemInterface
+{
 public:
-  DiffDriveArduino();
+  RCLCPP_SHARED_PTR_DEFINITIONS(DiffDriveArduino)
 
-  return_type configure(const hardware_interface::HardwareInfo & info) override;
+  HARDWARE_INTERFACE_PUBLIC
+  hardware_interface::CallbackReturn on_init(const hardware_interface::HardwareInfo & info) override;
 
+  HARDWARE_INTERFACE_PUBLIC
   std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
 
+  HARDWARE_INTERFACE_PUBLIC
   std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
 
-  return_type start() override;
+  HARDWARE_INTERFACE_PUBLIC
+  hardware_interface::CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state) override;
 
-  return_type stop() override;
+  HARDWARE_INTERFACE_PUBLIC
+  hardware_interface::CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state) override;
 
-  return_type read() override;
+  HARDWARE_INTERFACE_PUBLIC
+  hardware_interface::return_type read(
+    const rclcpp::Time & time, const rclcpp::Duration & period) override;
 
-  return_type write() override;
-
-
+  HARDWARE_INTERFACE_PUBLIC
+  hardware_interface::return_type write(
+    const rclcpp::Time & time, const rclcpp::Duration & period) override;
 
 private:
-
   Config cfg_;
   ArduinoComms arduino_;
-
   Wheel l_wheel_;
   Wheel r_wheel_;
-
   rclcpp::Logger logger_;
-
-  std::chrono::time_point<std::chrono::system_clock> time_;
-  
 };
 
+}  // namespace diffdrive_arduino
 
-#endif // DIFFDRIVE_ARDUINO_REAL_ROBOT_H
+#endif  // DIFFDRIVE_ARDUINO_REAL_ROBOT_H

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>diffdrive_arduino</name>
   <version>0.0.1</version>
   <description>Provides an interface between diff_drive_controller and an Arduino.</description>

--- a/src/diffdrive_arduino.cpp
+++ b/src/diffdrive_arduino.cpp
@@ -1,28 +1,21 @@
 #include "diffdrive_arduino/diffdrive_arduino.h"
 
-
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "pluginlib/class_list_macros.hpp"
 
-
-
-
-DiffDriveArduino::DiffDriveArduino()
-    : logger_(rclcpp::get_logger("DiffDriveArduino"))
-{}
-
-
-
-
-
-return_type DiffDriveArduino::configure(const hardware_interface::HardwareInfo & info)
+namespace diffdrive_arduino
 {
-  if (configure_default(info) != return_type::OK) {
-    return return_type::ERROR;
+hardware_interface::CallbackReturn DiffDriveArduino::on_init(
+  const hardware_interface::HardwareInfo & info)
+{
+  if (hardware_interface::SystemInterface::on_init(info) != hardware_interface::CallbackReturn::SUCCESS)
+  {
+    return hardware_interface::CallbackReturn::ERROR;
   }
 
-  RCLCPP_INFO(logger_, "Configuring...");
+  logger_ = rclcpp::get_logger("DiffDriveArduino");
 
-  time_ = std::chrono::system_clock::now();
+  RCLCPP_INFO(logger_, "Configuring...");
 
   cfg_.left_wheel_name = info_.hardware_parameters["left_wheel_name"];
   cfg_.right_wheel_name = info_.hardware_parameters["right_wheel_name"];
@@ -37,42 +30,43 @@ return_type DiffDriveArduino::configure(const hardware_interface::HardwareInfo &
   r_wheel_.setup(cfg_.right_wheel_name, cfg_.enc_counts_per_rev);
 
   // Set up the Arduino
-  arduino_.setup(cfg_.device, cfg_.baud_rate, cfg_.timeout);  
+  arduino_.setup(cfg_.device, cfg_.baud_rate, cfg_.timeout);
 
   RCLCPP_INFO(logger_, "Finished Configuration");
 
-  status_ = hardware_interface::status::CONFIGURED;
-  return return_type::OK;
+  return hardware_interface::CallbackReturn::SUCCESS;
 }
 
 std::vector<hardware_interface::StateInterface> DiffDriveArduino::export_state_interfaces()
 {
-  // We need to set up a position and a velocity interface for each wheel
-
   std::vector<hardware_interface::StateInterface> state_interfaces;
 
-  state_interfaces.emplace_back(hardware_interface::StateInterface(l_wheel_.name, hardware_interface::HW_IF_VELOCITY, &l_wheel_.vel));
-  state_interfaces.emplace_back(hardware_interface::StateInterface(l_wheel_.name, hardware_interface::HW_IF_POSITION, &l_wheel_.pos));
-  state_interfaces.emplace_back(hardware_interface::StateInterface(r_wheel_.name, hardware_interface::HW_IF_VELOCITY, &r_wheel_.vel));
-  state_interfaces.emplace_back(hardware_interface::StateInterface(r_wheel_.name, hardware_interface::HW_IF_POSITION, &r_wheel_.pos));
+  state_interfaces.emplace_back(hardware_interface::StateInterface(
+    l_wheel_.name, hardware_interface::HW_IF_VELOCITY, &l_wheel_.vel));
+  state_interfaces.emplace_back(hardware_interface::StateInterface(
+    l_wheel_.name, hardware_interface::HW_IF_POSITION, &l_wheel_.pos));
+  state_interfaces.emplace_back(hardware_interface::StateInterface(
+    r_wheel_.name, hardware_interface::HW_IF_VELOCITY, &r_wheel_.vel));
+  state_interfaces.emplace_back(hardware_interface::StateInterface(
+    r_wheel_.name, hardware_interface::HW_IF_POSITION, &r_wheel_.pos));
 
   return state_interfaces;
 }
 
 std::vector<hardware_interface::CommandInterface> DiffDriveArduino::export_command_interfaces()
 {
-  // We need to set up a velocity command interface for each wheel
-
   std::vector<hardware_interface::CommandInterface> command_interfaces;
 
-  command_interfaces.emplace_back(hardware_interface::CommandInterface(l_wheel_.name, hardware_interface::HW_IF_VELOCITY, &l_wheel_.cmd));
-  command_interfaces.emplace_back(hardware_interface::CommandInterface(r_wheel_.name, hardware_interface::HW_IF_VELOCITY, &r_wheel_.cmd));
+  command_interfaces.emplace_back(hardware_interface::CommandInterface(
+    l_wheel_.name, hardware_interface::HW_IF_VELOCITY, &l_wheel_.cmd));
+  command_interfaces.emplace_back(hardware_interface::CommandInterface(
+    r_wheel_.name, hardware_interface::HW_IF_VELOCITY, &r_wheel_.cmd));
 
   return command_interfaces;
 }
 
-
-return_type DiffDriveArduino::start()
+hardware_interface::CallbackReturn DiffDriveArduino::on_activate(
+  const rclcpp_lifecycle::State & /*previous_state*/)
 {
   RCLCPP_INFO(logger_, "Starting Controller...");
 
@@ -81,37 +75,28 @@ return_type DiffDriveArduino::start()
   // arduino.setPidValues(14,7,0,100);
   arduino_.setPidValues(30, 20, 0, 100);
 
-  status_ = hardware_interface::status::STARTED;
-
-  return return_type::OK;
+  return hardware_interface::CallbackReturn::SUCCESS;
 }
 
-return_type DiffDriveArduino::stop()
+hardware_interface::CallbackReturn DiffDriveArduino::on_deactivate(
+  const rclcpp_lifecycle::State & /*previous_state*/)
 {
   RCLCPP_INFO(logger_, "Stopping Controller...");
-  status_ = hardware_interface::status::STOPPED;
 
-  return return_type::OK;
+  return hardware_interface::CallbackReturn::SUCCESS;
 }
 
-hardware_interface::return_type DiffDriveArduino::read()
+hardware_interface::return_type DiffDriveArduino::read(
+  const rclcpp::Time & /*time*/, const rclcpp::Duration & period)
 {
-
-  // TODO fix chrono duration
-
-  // Calculate time delta
-  auto new_time = std::chrono::system_clock::now();
-  std::chrono::duration<double> diff = new_time - time_;
-  double deltaSeconds = diff.count();
-  time_ = new_time;
-
-
   if (!arduino_.connected())
   {
-    return return_type::ERROR;
+    return hardware_interface::return_type::ERROR;
   }
 
   arduino_.readEncoderValues(l_wheel_.enc, r_wheel_.enc);
+
+  double deltaSeconds = period.seconds();
 
   double pos_prev = l_wheel_.pos;
   l_wheel_.pos = l_wheel_.calcEncAngle();
@@ -121,37 +106,25 @@ hardware_interface::return_type DiffDriveArduino::read()
   r_wheel_.pos = r_wheel_.calcEncAngle();
   r_wheel_.vel = (r_wheel_.pos - pos_prev) / deltaSeconds;
 
-
-
-  return return_type::OK;
-
-  
+  return hardware_interface::return_type::OK;
 }
 
-hardware_interface::return_type DiffDriveArduino::write()
+hardware_interface::return_type DiffDriveArduino::write(
+  const rclcpp::Time & /*time*/, const rclcpp::Duration & period)
 {
-
   if (!arduino_.connected())
   {
-    return return_type::ERROR;
+    return hardware_interface::return_type::ERROR;
   }
 
-  arduino_.setMotorValues(l_wheel_.cmd / l_wheel_.rads_per_count / cfg_.loop_rate, r_wheel_.cmd / r_wheel_.rads_per_count / cfg_.loop_rate);
+  arduino_.setMotorValues(
+    l_wheel_.cmd / l_wheel_.rads_per_count / cfg_.loop_rate,
+    r_wheel_.cmd / r_wheel_.rads_per_count / cfg_.loop_rate);
 
-
-
-
-  return return_type::OK;
-
-
-  
+  return hardware_interface::return_type::OK;
 }
 
-
-
-#include "pluginlib/class_list_macros.hpp"
+}  // namespace diffdrive_arduino
 
 PLUGINLIB_EXPORT_CLASS(
-  DiffDriveArduino,
-  hardware_interface::SystemInterface
-)
+  diffdrive_arduino::DiffDriveArduino, hardware_interface::SystemInterface)


### PR DESCRIPTION
This commit updates the `diffdrive_arduino` package to be compatible with ROS 2 Humble.

The main changes include:
- Updating the package.xml to format 3.
- Setting the C++ standard to 17 in CMakeLists.txt.
- Refactoring the hardware interface to align with the new `ros2_control` API in Humble. This involves:
  - Inheriting from `hardware_interface::SystemInterface` directly.
  - Renaming lifecycle methods (e.g., `configure` -> `on_init`, `start` -> `on_activate`).
  - Using `hardware_interface::CallbackReturn` for lifecycle methods.
  - Updating the signatures of `read` and `write` methods.